### PR TITLE
fix: SPA 딥링크 404 수정 및 CI 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type check & build
+        run: npm run build
+      - name: SPA 딥링크 폴백 검증
+        run: npm run check:spa-fallback

--- a/.github/workflows/smoke-live.yml
+++ b/.github/workflows/smoke-live.yml
@@ -1,0 +1,18 @@
+name: Smoke (live)
+
+# 배포된 사이트의 딥링크 폴백을 사후 감시한다.
+# 배포가 수동(gh-pages)이라 PR 시점에는 확인할 수 없으므로, 수동 실행과 주기 실행으로 확인한다.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1" # 매주 월요일 00:00 UTC
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/smoke-live.mjs

--- a/docs/2026-07-11-spa-deeplink-404.md
+++ b/docs/2026-07-11-spa-deeplink-404.md
@@ -1,0 +1,100 @@
+# SPA 딥링크 404 수정 및 CI 도입
+
+- 작업일: 2026-07-11
+- 관련 PR: #28
+- 발견 경로: 포트폴리오 점검 중 AI 코드 리뷰(Claude Code)로 지적받고, 직접 재현·검증 후 수정
+
+## 요약
+
+배포된 사이트에서 홈을 제외한 모든 경로가 새로고침·직접 접근 시 404였다.
+문서를 검색 가능하게 만든다는 프로젝트 목적과 정면으로 충돌하는 상태였다.
+
+---
+
+## 문제 — 딥링크가 전부 404
+
+### 증상
+```
+GET https://dohyuk-centric.github.io/eslint-kr/        → 200
+GET https://dohyuk-centric.github.io/eslint-kr/rules   → 404
+GET https://dohyuk-centric.github.io/eslint-kr/intro   → 404
+```
+홈에서 메뉴를 클릭해 들어가면 동작하지만(클라이언트 라우팅),
+링크를 공유받거나 검색으로 유입되거나 새로고침하면 문서를 볼 수 없었다.
+
+### 원인
+`main.tsx`에서 `BrowserRouter(basename="/eslint-kr/")`를 쓰는데,
+GitHub Pages는 정적 파일 서버라 `/eslint-kr/rules` 경로의 파일이 없으면 404를 반환한다.
+SPA 딥링크를 index.html로 되돌려주는 폴백이 없었다. (`public/`에 favicon.svg 하나뿐)
+
+---
+
+## 수정 — spa-github-pages 방식
+
+| 파일 | 역할 |
+|---|---|
+| `public/404.html` | 요청 경로를 `/?/rules` 형태로 인코딩해 프로젝트 루트로 리다이렉트 |
+| `index.html` | 라우터 초기화 **전에** 원래 경로로 복원하는 스크립트 (`<head>` 상단 배치) |
+
+`base`가 `/eslint-kr/`이므로 유지할 경로 세그먼트(`pathSegmentsToKeep`)는 1이다.
+복원 스크립트가 메인 모듈(`assets/index-*.js`)보다 먼저 실행되어야 하므로 순서가 중요하다.
+
+### 동작 흐름
+```
+사용자가 /eslint-kr/rules 직접 접근
+  → GitHub Pages: 404 상태 + 404.html 본문
+  → 404.html: /eslint-kr/?/rules 로 리다이렉트
+  → GitHub Pages: 200 + index.html
+  → index.html 복원 스크립트: history.replaceState 로 /eslint-kr/rules 복구
+  → React Router 렌더
+```
+
+### 검증
+
+**1. 리다이렉트 → 복원 왕복 시뮬레이션** (쿼리·해시 포함 7개 경우, 모두 통과)
+```
+PASS /eslint-kr/rules
+PASS /eslint-kr/rules?q=1&x=2
+PASS /eslint-kr/rules#section-3
+PASS /eslint-kr/
+```
+
+**2. GitHub Pages 서빙을 흉내낸 정적 서버로 엔드투엔드**
+```
+홈 /eslint-kr/                 → 200
+딥링크 /eslint-kr/rules        → 404 + 404.html(리다이렉트 스크립트 포함)
+리다이렉트 착지 /?/rules       → 200 (index.html)
+에셋                          → 200
+```
+
+---
+
+## 재발 방지 CI (이 저장소엔 워크플로가 없었다)
+
+`.github`에 `ISSUE_TEMPLATE`만 있고 `workflows`가 비어 있었다.
+ESLint 홍보 사이트인데 CI에서 ESLint를 돌리지 않는 상태이기도 했다.
+
+- **`ci.yml`** — PR마다 `lint` + `tsc/build` 실행 후, `scripts/check-spa-fallback.mjs`로
+  빌드 산출물에 폴백이 연결됐는지 검증. `404.html`이나 복원 스크립트가 빠지면 빌드 실패.
+  (404.html을 지우고 실패하는 것 확인)
+- **`smoke-live.yml`** — 배포가 수동(`gh-pages`)이라 PR 시점엔 확인 불가하므로,
+  주간 스케줄 + 수동 실행으로 배포본 딥링크를 감시.
+
+---
+
+## ⚠️ 남은 한계 — SEO
+
+첫 응답이 **HTTP 404 상태**다. 사람에겐 즉시 리다이렉트되지만 검색 크롤러에는 여전히
+404로 보인다. 이 사이트의 존재 이유가 검색 노출인 만큼, 완전한 해결은 다음 중 하나다.
+
+- **Vercel/Netlify 이전** — rewrite로 모든 경로를 index.html에 200으로 매핑.
+  (메인 프로젝트 myBlog가 이미 Vercel을 쓰므로 현실적인 선택지)
+- **라우트별 프리렌더링(SSG)** — SEO까지 해결.
+
+이 PR은 "사람이 링크를 열면 동작한다"까지를 보장하고, 위 단계는 후속으로 남긴다.
+
+## 곁들여 (이번 범위 밖)
+
+문서 콘텐츠가 `RulesReference.tsx`(947줄) 등 TSX에 하드코딩돼 있어,
+`docs_translation.yml` 이슈 템플릿으로 번역 기여를 받겠다는 목표와 충돌한다.
+콘텐츠를 MDX/마크다운으로 분리하면 기여 장벽이 사라지고 위의 SSG 경로도 함께 열린다.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,29 @@
       rel="stylesheet"
     />
     <link rel="icon" href="%BASE_URL%favicon.svg" />
+    <!--
+      404.html이 딥링크를 '/?/rules' 형태로 인코딩해 보낸 경우,
+      React Router가 초기화되기 전에 원래 경로(/eslint-kr/rules)로 복원한다.
+      참고: https://github.com/rafgraph/spa-github-pages
+    -->
+    <script type="text/javascript">
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash,
+          );
+        }
+      })(window.location);
+    </script>
     <style>
       /* 랜딩 전용 스타일 */
       .hero {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "check:spa-fallback": "node scripts/check-spa-fallback.mjs",
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist"
   },

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <title>ESLint 한국어 가이드</title>
+    <!--
+      GitHub Pages는 SPA의 딥링크(예: /eslint-kr/rules)를 새로고침하거나 직접 열면
+      해당 경로의 파일이 없으므로 이 404.html을 반환한다.
+      여기서 경로를 쿼리스트링으로 인코딩해 프로젝트 루트로 리다이렉트하고,
+      index.html의 복원 스크립트가 원래 경로로 되돌린 뒤 React Router가 렌더링한다.
+      base가 '/eslint-kr/' 이므로 유지할 경로 세그먼트는 1개다.
+      참고: https://github.com/rafgraph/spa-github-pages
+    -->
+    <script type="text/javascript">
+      var pathSegmentsToKeep = 1;
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash,
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/scripts/check-spa-fallback.mjs
+++ b/scripts/check-spa-fallback.mjs
@@ -1,0 +1,41 @@
+// 빌드 산출물에 GitHub Pages SPA 딥링크 폴백이 제대로 연결됐는지 검증한다.
+// 이 파일들이 없거나 스크립트가 빠지면, 배포된 사이트에서 홈을 제외한
+// 모든 경로가 새로고침/직접 접근 시 404가 된다. (실제로 그런 상태였다.)
+import { readFile } from "node:fs/promises";
+
+const checks = [
+  {
+    file: "dist/404.html",
+    must: "pathSegmentsToKeep",
+    why: "404.html의 딥링크 리다이렉트 스크립트",
+  },
+  {
+    file: "dist/index.html",
+    must: 'l.search[1] === "/"',
+    why: "index.html의 경로 복원 스크립트",
+  },
+];
+
+let failed = false;
+for (const { file, must, why } of checks) {
+  let content;
+  try {
+    content = await readFile(file, "utf8");
+  } catch {
+    console.error(`✖ ${file} 이 없습니다 — ${why}`);
+    failed = true;
+    continue;
+  }
+  if (!content.includes(must)) {
+    console.error(`✖ ${file} 에 ${why}가 없습니다 (찾는 문자열: ${must})`);
+    failed = true;
+  } else {
+    console.log(`✔ ${file}: ${why} 확인`);
+  }
+}
+
+if (failed) {
+  console.error("\nSPA 딥링크 폴백이 깨졌습니다. public/404.html 과 index.html 복원 스크립트를 확인하세요.");
+  process.exit(1);
+}
+console.log("\nSPA 딥링크 폴백 정상.");

--- a/scripts/smoke-live.mjs
+++ b/scripts/smoke-live.mjs
@@ -1,0 +1,34 @@
+// 배포된 사이트에서 딥링크 폴백이 실제로 동작하는지 확인한다.
+//   - 홈은 200이어야 한다.
+//   - 딥링크는 GitHub Pages 특성상 404 상태로 오지만, 본문은 404.html이며
+//     리다이렉트 스크립트를 포함해야 한다. (그래야 브라우저가 정상 경로로 이동한다.)
+// 배포는 수동(gh-pages)이므로 이 스크립트는 스케줄/수동 실행으로 사후 감시한다.
+const BASE = process.env.SITE_BASE || "https://dohyuk-centric.github.io/eslint-kr";
+const ROUTES = ["intro", "install", "setting", "rules", "rulesReference", "settingFile", "parser", "plugin", "prettier"];
+
+async function get(url) {
+  const res = await fetch(url, { redirect: "manual" });
+  return { status: res.status, body: await res.text() };
+}
+
+let failed = false;
+function check(cond, msg) {
+  console.log((cond ? "✔ " : "✖ ") + msg);
+  if (!cond) failed = true;
+}
+
+const home = await get(BASE + "/");
+check(home.status === 200, `홈 200 (실제 ${home.status})`);
+
+for (const r of ROUTES) {
+  const { status, body } = await get(`${BASE}/${r}`);
+  // 정상 배포 상태: 200(파일 존재, 드묾) 이거나 404 + 폴백 스크립트
+  const ok = status === 200 || (status === 404 && body.includes("pathSegmentsToKeep"));
+  check(ok, `/${r} 폴백 동작 (status ${status})`);
+}
+
+if (failed) {
+  console.error("\n딥링크 폴백이 배포본에서 동작하지 않습니다. 404.html이 배포됐는지 확인하세요.");
+  process.exit(1);
+}
+console.log("\n배포본 딥링크 폴백 정상.");


### PR DESCRIPTION
## 문제

배포된 사이트에서 **홈을 제외한 모든 경로가 새로고침·직접 접근 시 404**입니다.

```
GET https://dohyuk-centric.github.io/eslint-kr/        → 200
GET https://dohyuk-centric.github.io/eslint-kr/rules   → 404
GET https://dohyuk-centric.github.io/eslint-kr/intro   → 404
```

`BrowserRouter(basename="/eslint-kr/")`를 쓰는데 GitHub Pages에는 클라이언트 라우팅 폴백이 없어서, 홈에서 클릭해 들어가면 동작하지만 **링크를 공유받거나 검색으로 유입되거나 새로고침하면 문서를 볼 수 없습니다.** 한국어 ESLint 문서를 검색 가능하게 만든다는 이 프로젝트의 목적과 정면으로 충돌하는 상태였습니다.

## 수정 — spa-github-pages 방식

| 파일 | 역할 |
|---|---|
| `public/404.html` | 요청 경로를 `/?/rules` 형태로 인코딩해 프로젝트 루트로 리다이렉트 |
| `index.html` | 라우터 초기화 **전에** 원래 경로로 복원하는 스크립트 (`<head>` 상단 배치) |

`base`가 `/eslint-kr/`이므로 유지할 경로 세그먼트는 1개입니다.

### 검증

**1. 리다이렉트 → 복원 왕복 시뮬레이션** (쿼리·해시 포함 7개 경우)

```
PASS /eslint-kr/rules
PASS /eslint-kr/rules?q=1&x=2
PASS /eslint-kr/rules#section-3
PASS /eslint-kr/          ...
=> 모든 왕복 통과
```

**2. GitHub Pages 서빙을 흉내낸 정적 서버로 엔드투엔드**

```
홈 /eslint-kr/                 → 200
딥링크 /eslint-kr/rules        → 404 상태 + 404.html(리다이렉트 스크립트 포함)
리다이렉트 착지 /?/rules       → 200 (index.html → 복원 → /eslint-kr/rules 렌더)
에셋                          → 200
```

즉 사람이 링크를 열거나 새로고침하면 정상 동작합니다.

## 재발 방지 CI (이 저장소엔 워크플로가 없었습니다)

`.github`에 `ISSUE_TEMPLATE`만 있고 `workflows`가 비어 있었습니다. ESLint 홍보 사이트인데 CI에서 ESLint를 돌리지 않는 상태이기도 했습니다.

- **`ci.yml`** — PR마다 `lint` + `tsc/build` 실행 후, `scripts/check-spa-fallback.mjs`로 빌드 산출물에 폴백이 연결됐는지 검증합니다. `404.html`이나 복원 스크립트가 빠지면 빌드가 실패합니다. (404.html을 지우고 실패하는 것 확인함)
- **`smoke-live.yml`** — 배포가 수동(`gh-pages`)이라 PR 시점엔 확인 불가하므로, 주간 스케줄 + 수동 실행으로 배포본 딥링크를 감시합니다.

## ⚠️ 남은 한계 (정직하게)

첫 응답이 **HTTP 404 상태**입니다. 사람에겐 즉시 리다이렉트되지만 **검색 크롤러에는 여전히 404로 보입니다.** 이 사이트의 존재 이유가 검색 노출인 만큼, 완전한 해결은 다음 중 하나입니다.

- rewrite를 지원하는 호스팅(Vercel/Netlify)으로 이전 → 200 + 깨끗한 URL
- 라우트별 프리렌더링(SSG) 도입 → SEO까지 해결

이 PR은 "사람이 링크를 열면 동작한다"까지를 확실히 보장하고, 그 위 단계는 별도 작업으로 남깁니다.

## 곁들여 제안 (이 PR 밖)

문서 콘텐츠가 `RulesReference.tsx`(947줄) 등 TSX에 하드코딩돼 있어, `docs_translation.yml` 이슈 템플릿으로 번역 기여를 받겠다는 목표와 충돌합니다. 콘텐츠를 MDX/마크다운으로 분리하면 기여 장벽이 사라지고 위의 SSG 경로도 함께 열립니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
